### PR TITLE
Added capacity to render OnScreen custom element

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ import { OnScreen } from '@ukorvl/react-on-screen';
 const MyComponent = () => (
   <OnScreen>
     {({isOnScreen, ref}) => (
-     <div ref={ref}>
-      {isOnScreen ? 'On screen!' : 'Not on screen'}
+      <div ref={ref}>
+        {isOnScreen ? 'On screen!' : 'Not on screen'}
       </div>
     )}
   </OnScreen>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Lightweight typescript library to detect React elements visibility
 [![Test](https://github.com/NilFoundation/react-components/actions/workflows/test.yaml/badge.svg)](https://github.com/NilFoundation/react-components/actions/workflows/test.yaml)
 [![Npm version](https://img.shields.io/npm/v/@ukorvl/react-on-screen)](https://www.npmjs.com/package/@ukorvl/react-on-screen)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Minified size](https://img.shields.io/bundlephobia/min/@ukorvl/react-on-screen)](https://bundlephobia.com/package/@ukorvl/react-on-screen)
 
 ## Table of contents
   - [Getting started](#getting-started)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,47 @@ or CDN
 
 This library is using Intersection observer API under the hood, so you may need to polyfill it. More information about Intersection observer API browser support at [caniuse](https://caniuse.com/intersectionobserver).
 
+### Render props
+```tsx
+import { OnScreen } from '@ukorvl/react-on-screen';
+
+const MyComponent = () => (
+  <OnScreen>
+    {({isOnScreen, ref}) => (
+     <div ref={ref}>
+      {isOnScreen ? 'On screen!' : 'Not on screen'}
+      </div>
+    )}
+  </OnScreen>
+)
+```
+
+### Hook
+```tsx
+import useOnScreen from '@ukorvl/react-on-screen';
+
+const MyComponent = () => {
+  const ref = useRef<T>(null);
+  const isOnScreen = useOnScreen({ref});
+
+  return (
+    <div ref={ref}>{isOnScreen ? 'On screen!' : 'Not on screen'}</div>
+  )
+}
+```
+
+### HOC
+```tsx
+const List = ({isOnScreen, ref, ...restProps}: ListProps) => (
+  <ul className={isOnScreen ? 'my-class' : ''} {...restProps}>
+    <li>Something</li>
+      {'...'}
+  </ul>
+)
+
+export const ListWithOnScreen = WithOnScreen(List, {threshold: 0.5, margin: '4rem'});
+```
+
 ## License
 
 [MIT](http://opensource.org/licenses/MIT)

--- a/lib/OnScreen.tsx
+++ b/lib/OnScreen.tsx
@@ -51,7 +51,7 @@ export const OnScreen = <T extends HTMLElement>({
   const isOnScreen = useOnScreen({ ref, ...rest });
   const renderer = useCallback(
     () => Children.only(children({ ref, isOnScreen })),
-    [isOnScreen],
+    [isOnScreen, children, ref],
   );
 
   if (As !== undefined) {

--- a/lib/useOnScreen.tsx
+++ b/lib/useOnScreen.tsx
@@ -32,7 +32,7 @@ export type UseOnScreenSettings<T extends HTMLElement> = {
  * const ref = useRef<T>(null);
  * const isOnScreen = useOnScreen({ref});
  *
- * return (<div>{isOnScreen ? 'I am on screen!' : 'I'm not on screen'}</div>);
+ * return (<div ref={ref}>{isOnScreen ? 'On screen!' : 'Not on screen'}</div>);
  * ```
  * @param {UseOnScreenSettings} useOnScreenProps - Props.
  * @returns - Is element on screen.

--- a/lib/useOnScreen.tsx
+++ b/lib/useOnScreen.tsx
@@ -66,7 +66,7 @@ export const useOnScreen = <T extends HTMLElement>({
     return () => {
       observer.disconnect();
     };
-  }, [ref, threshold, once]);
+  }, [ref, threshold, once, margin]);
 
   return isIntersecting;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@ukorvl/react-on-screen",
       "version": "1.0.0-beta.0",
+      "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^8.19.1",
         "@testing-library/jest-dom": "^5.16.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukorvl/react-on-screen",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukorvl/react-on-screen",
-      "version": "1.0.0-beta.0",
+      "version": "1.0.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^8.19.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-plugin-jest": "^27.2.0",
         "eslint-plugin-jsdoc": "^39.6.4",
         "eslint-plugin-react": "^7.31.11",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "husky": "^8.0.2",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
@@ -2937,6 +2938,18 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -8948,6 +8961,13 @@
           }
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-jest": "^27.2.0",
     "eslint-plugin-jsdoc": "^39.6.4",
     "eslint-plugin-react": "^7.31.11",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.2",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
@@ -78,7 +79,8 @@
     "extends": [
       "eslint:recommended",
       "plugin:react/recommended",
-      "plugin:jsdoc/recommended"
+      "plugin:jsdoc/recommended",
+      "plugin:react-hooks/recommended"
     ],
     "ignorePatterns": [
       "node_modules",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukorvl/react-on-screen",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "Lightweight typescript library to detect React elements visibility",
   "license": "MIT",
   "author": "ukorvl",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     ],
     "rules": {
       "no-unused-vars": "off",
+      "no-duplicate-imports": "warn",
       "jsdoc/newline-after-description": "off",
       "jsdoc/require-returns-type": "off",
       "jsdoc/require-param-type": "off",


### PR DESCRIPTION
Added **as** property of OnScreen component to allow rendering any custom element. If **as** prop is omitted, component will render nothing. Simple example below:
```tsx
import Container from 'react-bootstrap/Container';
import { OnScreen } from '@ukorvl/react-on-screen';

export const MyComponent = () => {
  return (
    <OnScreen once as={Container} fluid> // Use Container component props as well
      {({isOnScreen, ref}) => (
        <Row md={4} ref={ref} className={isOnScreen ? 'show-my-animation' : ''}>
          Something
        </Row>
      )}
    </OnScreen>
  )
}
```

Also minor readme, code-style and comments changes were made.