### PR TITLE
Added multiply thresholds and return visibilityRation value

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,20 +21,7 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Cache dependencies
-        id: cache-node-modules
-        uses: actions/cache@v3
-        env:
-          CACHE_NAME: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-cache-
-            ${{ runner.os }}-
-
       - name: Install dependencies
-        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
         run : npm ci --ignore-scripts
 
       - name: Lint

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ import useOnScreen from '@ukorvl/react-on-screen';
 
 const MyComponent = () => {
   const ref = useRef<T>(null);
-  const isOnScreen = useOnScreen({ref});
+  const {isOnScreen} = useOnScreen({ref});
 
   return (
     <div ref={ref}>{isOnScreen ? 'On screen!' : 'Not on screen'}</div>

--- a/lib/OnScreen.tsx
+++ b/lib/OnScreen.tsx
@@ -58,12 +58,19 @@ export const OnScreen = <
   margin,
   threshold,
   once,
+  onVisibilityChange,
   as,
   ...restProps
 }: OnScreenProps<T, AS>): ReactElement => {
   const Component: ElementType | undefined = as;
   const ref = useRef<T>(null);
-  const isOnScreen = useOnScreen({ ref, margin, threshold, once });
+  const isOnScreen = useOnScreen({
+    ref,
+    margin,
+    threshold,
+    once,
+    onVisibilityChange,
+  });
 
   const renderChildren = useCallback(
     () => Children.only(children({ ref, isOnScreen })),

--- a/lib/OnScreen.tsx
+++ b/lib/OnScreen.tsx
@@ -19,7 +19,9 @@ type OnScreenOwnProps<
   /**
    * Render function.
    */
-  children: (props: { isOnScreen: boolean; ref: RefObject<T> }) => ReactElement;
+  children: (
+    props: { ref: RefObject<T> } & ReturnType<typeof useOnScreen>,
+  ) => ReactElement;
   /**
    * Element to render.
    */
@@ -58,23 +60,21 @@ export const OnScreen = <
   margin,
   threshold,
   once,
-  onVisibilityChange,
   as,
   ...restProps
 }: OnScreenProps<T, AS>): ReactElement => {
   const Component: ElementType | undefined = as;
   const ref = useRef<T>(null);
-  const isOnScreen = useOnScreen({
+  const useOnScreenData = useOnScreen({
     ref,
     margin,
     threshold,
     once,
-    onVisibilityChange,
   });
 
   const renderChildren = useCallback(
-    () => Children.only(children({ ref, isOnScreen })),
-    [isOnScreen, children, ref],
+    () => Children.only(children({ ref, ...useOnScreenData })),
+    [useOnScreenData, children, ref],
   );
 
   if (Component !== undefined) {

--- a/lib/useOnScreen.tsx
+++ b/lib/useOnScreen.tsx
@@ -28,31 +28,13 @@ export type UseOnScreenSettings<T extends HTMLElement> = {
    * @example ```50px 0 0 | 50px | 2rem 3rem```
    */
   margin?: string;
-  /**
-   * Callback to execute every time visibility passes a threshold.
-   */
-  onVisibilityChange?: OnVisibilityChangeCb;
 };
-
-/**
- * Callback to execute every time visibility passes a threshold.
- */
-export type OnVisibilityChangeCb = (params: {
-  /**
-   * Is element on screen.
-   */
-  isOnScreen: boolean;
-  /**
-   * Element visibility ratio.
-   */
-  visibilityRatio: number;
-}) => void;
 
 /**
  * Hook detects wether element is on screen or not.
  * @example ```tsx
  * const ref = useRef<T>(null);
- * const isOnScreen = useOnScreen({ref});
+ * const {isOnScreen} = useOnScreen({ref});
  *
  * return (<div ref={ref}>{isOnScreen ? 'On screen!' : 'Not on screen'}</div>);
  * ```
@@ -64,9 +46,9 @@ export const useOnScreen = <T extends HTMLElement>({
   threshold = 0,
   once = false,
   margin,
-  onVisibilityChange,
-}: UseOnScreenSettings<T>): boolean => {
+}: UseOnScreenSettings<T>) => {
   const [isIntersecting, setIntersecting] = useState(false);
+  const [intersectionRatio, setIntersectionRatio] = useState<number>();
 
   useEffect(() => {
     if (!ref.current) {
@@ -78,12 +60,7 @@ export const useOnScreen = <T extends HTMLElement>({
         const { isIntersecting, intersectionRatio } = entry;
 
         setIntersecting(isIntersecting);
-
-        onVisibilityChange &&
-          onVisibilityChange({
-            isOnScreen: isIntersecting,
-            visibilityRatio: intersectionRatio,
-          });
+        setIntersectionRatio(intersectionRatio);
 
         once && isIntersecting && observer.disconnect();
       },
@@ -98,7 +75,10 @@ export const useOnScreen = <T extends HTMLElement>({
     return () => {
       observer.disconnect();
     };
-  }, [ref, threshold, once, margin, onVisibilityChange]);
+  }, [ref, threshold, once, margin]);
 
-  return isIntersecting;
+  return {
+    isOnScreen: isIntersecting,
+    visibilityRatio: intersectionRatio,
+  };
 };

--- a/lib/useOnScreen.tsx
+++ b/lib/useOnScreen.tsx
@@ -29,13 +29,13 @@ export type UseOnScreenSettings<T extends HTMLElement> = {
    */
   margin?: string;
   /**
-   * Callback to execute on visibility change.
+   * Callback to execute every time visibility passes a threshold.
    */
   onVisibilityChange?: OnVisibilityChangeCb;
 };
 
 /**
- * Callback to execute on visibility change
+ * Callback to execute every time visibility passes a threshold.
  */
 export type OnVisibilityChangeCb = (params: {
   /**

--- a/lib/withOnScreen.tsx
+++ b/lib/withOnScreen.tsx
@@ -26,12 +26,12 @@ export const withOnScreen = <
 ) => {
   const WithOnScreen = (props: P, forwardedRef: ForwardedRef<T>) => {
     const ref = useRef<T>(null);
-    const isOnScreen = useOnScreen({ ref, ...settings });
+    const useOnScreenData = useOnScreen({ ref, ...settings });
 
     return (
       <WrappedComponent
-        isOnScreen={isOnScreen}
         ref={assignRefs(ref, forwardedRef)}
+        {...useOnScreenData}
         {...props}
       />
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukorvl/react-on-screen",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukorvl/react-on-screen",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^8.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukorvl/react-on-screen",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Lightweight typescript library to detect React elements visibility",
   "license": "MIT",
   "author": "ukorvl",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
       "jsdoc/newline-after-description": "off",
       "jsdoc/require-returns-type": "off",
       "jsdoc/require-param-type": "off",
+      "jsdoc/require-description-complete-sentence": "warn",
+      "jsdoc/check-indentation": "warn",
       "jsdoc/require-jsdoc": [
         "warn",
         {


### PR DESCRIPTION
Add capacity to provide multiply thresholds, according with IntersectionObserver API. If array of thresholds is provided, visibility detection will be triggered every time visibility passes one of provided thresholds. That could be useful to execute some effects several times, while element is partially visible. Simple example:
```tsx
...
const { visibilityRatio }  = useOnScreen({ref});
useEffect(() => {
  switch (true) {
    case 0 < visibilityRatio =< 0.3: {
      ...some effect
      break;
    };
    case 0.3 < visibilityRatio < 0.5: {
      ...another effect
    }
    ...
  }
}, [visibilityRatio]);
```