### PR TITLE
Added unit-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ yarn add @ukorvl/react-on-screen
 ```
 The standalone version creates window.ReactOnScreen object with all exports from esm version.
 
-Note, that ```react``` package is not included into standalone version, but is required. Standalone version requires global React variable to work as expected.
+Note, that ```react``` package is not included into standalone version, but is required. Standalone version requires global ```React``` variable to work as expected.
 
 ## Usage
 

--- a/lib/__tests__/OnScreen.test.tsx
+++ b/lib/__tests__/OnScreen.test.tsx
@@ -1,11 +1,30 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import { OnScreen } from '../OnScreen';
+import {
+  ComponentRenderer,
+  createIsOnScreenValueTest,
+  createOnceParameterTest,
+  createRenderTest,
+} from './testUtils';
+
+const renderComponent: ComponentRenderer = settings => (
+  <OnScreen<HTMLDivElement> {...settings}>
+    {({ ref, isOnScreen }) => (
+      <div
+        ref={ref}
+        data-testid={`target${isOnScreen ? '-isOnScreen' : ''}`}
+      />
+    )}
+  </OnScreen>
+);
 
 describe('OnScreen', () => {
-  it('Component renders', () => {
-    const { container } = render(<OnScreen>{() => <p></p>}</OnScreen>);
+  it('OnScreen component renders', createRenderTest(renderComponent));
 
-    expect(container).toBeInTheDocument();
-  });
+  it('isOnScreen value changes', createIsOnScreenValueTest(renderComponent));
+
+  it(
+    'Once prop is working as expected',
+    createOnceParameterTest(renderComponent),
+  );
 });

--- a/lib/__tests__/testUtils.ts
+++ b/lib/__tests__/testUtils.ts
@@ -1,0 +1,71 @@
+/*global expect*/
+import { act, render } from '@testing-library/react';
+import { mockIntersectionObserver } from 'jsdom-testing-mocks';
+import { ReactElement } from 'react';
+import { UseOnScreenSettings } from '../useOnScreen';
+
+/**
+ * Renders component.
+ */
+export type ComponentRenderer = (
+  settings?: Pick<UseOnScreenSettings, 'once'>,
+) => ReactElement;
+
+const targetTestId = 'target';
+const targetIsOnScreenTestId = 'target-isOnScreen';
+
+const io = mockIntersectionObserver();
+
+/**
+ * Creates test to ensure component renders.
+ * @param renderComponent Renders component.
+ * @returns Test function.
+ */
+export const createRenderTest = (renderComponent: ComponentRenderer) => () => {
+  const { container } = render(renderComponent());
+
+  expect(container).toBeInTheDocument();
+};
+
+/**
+ * Creates test to ensure isOnScreen value changes.
+ * @param renderComponent Renders component.
+ * @returns Test function.
+ */
+export const createIsOnScreenValueTest =
+  (renderComponent: ComponentRenderer) => () => {
+    const { getByTestId, queryByTestId } = render(renderComponent());
+
+    expect(getByTestId(targetTestId)).toBeInTheDocument();
+    expect(queryByTestId(targetIsOnScreenTestId)).toBeNull();
+
+    act(() => {
+      io.enterNode(getByTestId(targetTestId));
+    });
+
+    expect(queryByTestId(targetIsOnScreenTestId)).toBeInTheDocument();
+  };
+
+/**
+ * Creates test to ensure once parameter is working.
+ * @param renderComponent Renders component.
+ * @returns Test function.
+ */
+export const createOnceParameterTest =
+  (renderComponent: ComponentRenderer) => () => {
+    const { queryByTestId, getByTestId } = render(
+      renderComponent({ once: true }),
+    );
+
+    act(() => {
+      io.enterNode(getByTestId(targetTestId));
+    });
+
+    expect(queryByTestId(targetIsOnScreenTestId)).toBeInTheDocument();
+
+    act(() => {
+      io.leaveNode(getByTestId(targetIsOnScreenTestId));
+    });
+
+    expect(getByTestId(targetIsOnScreenTestId)).toBeInTheDocument();
+  };

--- a/lib/__tests__/useOnScreen.test.tsx
+++ b/lib/__tests__/useOnScreen.test.tsx
@@ -1,0 +1,35 @@
+import React, { useRef } from 'react';
+import { useOnScreen, UseOnScreenSettings } from '../useOnScreen';
+import {
+  ComponentRenderer,
+  createIsOnScreenValueTest,
+  createOnceParameterTest,
+  createRenderTest,
+} from './testUtils';
+
+const ComponentTemplate = (props: Pick<UseOnScreenSettings, 'once'>) => {
+  const ref = useRef(null);
+  const { isOnScreen } = useOnScreen({ ref, ...props });
+
+  return (
+    <div
+      ref={ref}
+      data-testid={`target${isOnScreen ? '-isOnScreen' : ''}`}
+    />
+  );
+};
+
+const renderComponent: ComponentRenderer = settings => (
+  <ComponentTemplate {...settings} />
+);
+
+describe('useOnScreen', () => {
+  it('useOnScreen component renders', createRenderTest(renderComponent));
+
+  it('isOnScreen value changes', createIsOnScreenValueTest(renderComponent));
+
+  it(
+    'Once prop is working as expected',
+    createOnceParameterTest(renderComponent),
+  );
+});

--- a/lib/__tests__/withOnScreen.test.tsx
+++ b/lib/__tests__/withOnScreen.test.tsx
@@ -1,0 +1,37 @@
+import React, { forwardRef } from 'react';
+import { useOnScreen } from '../useOnScreen';
+import { withOnScreen } from '../withOnScreen';
+import {
+  ComponentRenderer,
+  createIsOnScreenValueTest,
+  createOnceParameterTest,
+  createRenderTest,
+} from './testUtils';
+
+const ComponentTemplate = forwardRef<
+  HTMLDivElement,
+  ReturnType<typeof useOnScreen>
+>(function ComponentTemplate({ isOnScreen }, ref) {
+  return (
+    <div
+      ref={ref}
+      data-testid={`target${isOnScreen ? '-isOnScreen' : ''}`}
+    />
+  );
+});
+
+const renderComponent: ComponentRenderer = settings => {
+  const WithOnScreen = withOnScreen(ComponentTemplate, settings);
+  return <WithOnScreen />;
+};
+
+describe('withOnScreen', () => {
+  it('withOnScreen component renders', createRenderTest(renderComponent));
+
+  it('isOnScreen value changes', createIsOnScreenValueTest(renderComponent));
+
+  it(
+    'Once prop is working as expected',
+    createOnceParameterTest(renderComponent),
+  );
+});

--- a/lib/standalone.ts
+++ b/lib/standalone.ts
@@ -1,3 +1,0 @@
-import * as onScreen from './index';
-
-(window as any).ReactOnScreen = onScreen;

--- a/lib/useOnScreen.tsx
+++ b/lib/useOnScreen.tsx
@@ -3,7 +3,7 @@ import { RefObject, useEffect, useState } from 'react';
 /**
  * UseOnScreen hook settings.
  */
-export type UseOnScreenSettings<T extends HTMLElement> = {
+export type UseOnScreenSettings<T extends HTMLElement = HTMLElement> = {
   /**
    * Target React element ref.
    */
@@ -39,7 +39,7 @@ export type UseOnScreenSettings<T extends HTMLElement> = {
  * return (<div ref={ref}>{isOnScreen ? 'On screen!' : 'Not on screen'}</div>);
  * ```
  * @param {UseOnScreenSettings} useOnScreenProps - Props.
- * @returns - Is element on screen.
+ * @returns .
  */
 export const useOnScreen = <T extends HTMLElement>({
   ref,

--- a/lib/withOnScreen.tsx
+++ b/lib/withOnScreen.tsx
@@ -6,12 +6,13 @@ import { assignRefs } from './internal';
 /**
  * High order component that takes a component and injects onScreen props into it.
  * @example ```tsx
- * const List = ({isOnScreen, ref, ...restProps}: ListProps) => (
+ * const List = forwardRef(function List({isOnScreen, ...restProps}: ListProps) (
  *   <ul className={isOnScreen ? 'my-class' : ''} {...restProps}>
  *    <li>Something</li>
  *    ...
  *   </ul>
- * )
+ * ));
+ *
  * export const ListWithOnScreen = WithOnScreen(List, {threshold: 0.5, margin: '4rem'});
  * ```
  * @param WrappedComponent Component to inject props.
@@ -22,8 +23,8 @@ export const withOnScreen = <
   P extends Record<string, unknown>,
   T extends HTMLElement,
 >(
-  WrappedComponent: ComponentType<P>,
-  settings: Omit<UseOnScreenSettings<T>, 'ref'>,
+  WrappedComponent: ComponentType<P & ReturnType<typeof useOnScreen>>,
+  settings?: Omit<UseOnScreenSettings<T>, 'ref'>,
 ) => {
   const WithOnScreen = (props: P, forwardedRef: ForwardedRef<T>) => {
     const ref = useRef<T>(null);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukorvl/react-on-screen",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukorvl/react-on-screen",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "hoist-non-react-statics": "^3.3.2"
@@ -31,7 +31,9 @@
         "husky": "^8.0.2",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
+        "jsdom-testing-mocks": "^1.7.0",
         "prettier": "^2.8.1",
+        "rimraf": "^4.1.2",
         "rollup": "^2.79.1",
         "rollup-plugin-dts": "^4.2.3",
         "rollup-plugin-esbuild": "^5.0.0",
@@ -1699,6 +1701,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/@npmcli/move-file/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@npmcli/node-gyp": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.3.tgz",
@@ -2932,6 +2949,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/bezier-easing": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
+      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
+      "dev": true
+    },
     "node_modules/boxen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
@@ -3100,6 +3123,21 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cacache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/call-bind": {
@@ -3361,6 +3399,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
+      "dev": true
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -4385,6 +4429,21 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/flatted": {
@@ -6244,6 +6303,22 @@
         }
       }
     },
+    "node_modules/jsdom-testing-mocks": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom-testing-mocks/-/jsdom-testing-mocks-1.7.0.tgz",
+      "integrity": "sha512-KRb8zU8c+ANOCmszF8hi/oAYorbU5rWl00ccsDwq/Odfu2QdRK8oeXIziYGt6FDl5GZjqYSnOgnXDVHW5i/k2w==",
+      "dev": true,
+      "dependencies": {
+        "bezier-easing": "^2.1.0",
+        "css-mediaquery": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=17"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -6771,6 +6846,21 @@
         "node": ">= 10.12.0"
       }
     },
+    "node_modules/node-gyp/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/node-gyp/node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -7251,6 +7341,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/pacote/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/parent-module": {
@@ -7851,15 +7956,15 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.1.2.tgz",
+      "integrity": "sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==",
       "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -10283,6 +10388,17 @@
       "requires": {
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "@npmcli/node-gyp": {
@@ -11234,6 +11350,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bezier-easing": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
+      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
+      "dev": true
+    },
     "boxen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
@@ -11358,6 +11480,17 @@
         "ssri": "^8.0.1",
         "tar": "^6.0.2",
         "unique-filename": "^1.1.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "call-bind": {
@@ -11551,6 +11684,12 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
+      "dev": true
     },
     "css.escape": {
       "version": "1.5.1",
@@ -12338,6 +12477,17 @@
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -13720,6 +13870,16 @@
         "xml-name-validator": "^4.0.0"
       }
     },
+    "jsdom-testing-mocks": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom-testing-mocks/-/jsdom-testing-mocks-1.7.0.tgz",
+      "integrity": "sha512-KRb8zU8c+ANOCmszF8hi/oAYorbU5rWl00ccsDwq/Odfu2QdRK8oeXIziYGt6FDl5GZjqYSnOgnXDVHW5i/k2w==",
+      "dev": true,
+      "requires": {
+        "bezier-easing": "^2.1.0",
+        "css-mediaquery": "^0.1.2"
+      }
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -14127,6 +14287,15 @@
         "which": "^2.0.2"
       },
       "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "semver": {
           "version": "7.3.8",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -14483,6 +14652,17 @@
         "rimraf": "^3.0.2",
         "ssri": "^8.0.1",
         "tar": "^6.1.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "parent-module": {
@@ -14933,13 +15113,10 @@
       "dev": true
     },
     "rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.3"
-      }
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.1.2.tgz",
+      "integrity": "sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==",
+      "dev": true
     },
     "rollup": {
       "version": "2.79.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukorvl/react-on-screen",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.1",
   "description": "Lightweight typescript library to detect React elements visibility",
   "license": "MIT",
   "author": "ukorvl",
@@ -14,6 +14,7 @@
   ],
   "types": "build/typings.d.ts",
   "scripts": {
+    "prebuild": "rimraf build",
     "build": "rollup -c",
     "test": "jest",
     "lint": "eslint --ext=ts,tsx lib --max-warnings=0",
@@ -51,7 +52,9 @@
     "husky": "^8.0.2",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
+    "jsdom-testing-mocks": "^1.7.0",
     "prettier": "^2.8.1",
+    "rimraf": "^4.1.2",
     "rollup": "^2.79.1",
     "rollup-plugin-dts": "^4.2.3",
     "rollup-plugin-esbuild": "^5.0.0",
@@ -131,11 +134,20 @@
         ],
         "extends": [
           "plugin:jest/recommended"
-        ]
+        ],
+        "rules": {
+          "jest/expect-expect": "off"
+        }
       }
     ]
   },
   "jest": {
+    "roots": [
+      "<rootDir>/lib"
+    ],
+    "testMatch": [
+      "**/__tests__/**/*.test.{ts,tsx}"
+    ],
     "preset": "ts-jest",
     "testEnvironment": "jsdom",
     "setupFilesAfterEnv": [
@@ -144,7 +156,8 @@
     "testPathIgnorePatterns": [
       "<rootDir>/build/",
       "<rootDir>/node_modules/"
-    ]
+    ],
+    "resetMocks": true
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.3.2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,7 +28,7 @@ const getConfig = ({
   format,
   isStandalone = false,
 }) => ({
-  input,
+  input: 'lib/index.ts',
   output: {
     file: outputFile,
     format,
@@ -40,15 +40,18 @@ const getConfig = ({
   plugins: [
     nodeResolve(),
     commonjs(),
-    replace({
-      preventAssignment: true,
-      values: { 'process.env.NODE_ENV': JSON.stringify('production') },
-    }),
     esbuild({
       minify: true,
     }),
     filesize(),
-  ],
+  ].concat(
+    isStandalone
+      ? replace({
+        preventAssignment: true,
+        values: { 'process.env.NODE_ENV': JSON.stringify('production') },
+      })
+      : []
+  ),
   external: ['react', 'react-dom'].concat(isStandalone ? [] : ['hoist-non-react-statics'])
 });
 
@@ -61,17 +64,14 @@ const dtsConfig = {
 
 const configs = [
   getConfig({
-    input: 'lib/index.ts',
     outputFile: packageJson.main,
     format: 'cjs',
   }),
   getConfig({
-    input: 'lib/index.ts',
     outputFile: packageJson.module,
     format: 'esm',
   }),
   getConfig({
-    input: 'lib/standalone.ts',
     outputFile: packageJson.unpkg,
     format: 'iife',
     isStandalone: true,


### PR DESCRIPTION
Added unit-tests with ```jest```, using [jsdom-testing-mocks](https://github.com/trurl-master/jsdom-testing-mocks).

Some build process improvements made:
- Removed ```standalone.ts``` index file. Standalone build could be created from ```index.tsx``` instead (like ```esm``` and ```cjs``` builds), just using ```name``` rollup output parameter
- Replace plugin should be used to replace ```process.env``` only in standalone build
- Clear ```build``` dir before every new build

Extend ```withOnScreen``` WrappedComponent from ```ReturnType<typeof useOnScreen>```