### PR TITLE
Added initialVisibility prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ export const ListWithOnScreen = WithOnScreen(List, {threshold: 0.5, margin: '4re
 |threshold       |0                |Could be a single number from 0 to 1, or array of numbers. If you only want to detect when visibility passes the 50% mark, you can use a value of 0.5. Set 1 to consider visibility only if all element is on the screen.If array of thresholds is provided, visibility detection will be triggered every time visibility passes one of provided thresholds.|
 |margin          |undefined        |Could be any valid css margin value. This value serves to grow or shrink each side of the target element's bounding box before computing is it visible or not.|
 |once            |false            |Triggers visibility detection only once. Once target element becomes visible, visibility detection will be disabled.|
+|initialVisibility |false          |Initial isOnScreen value. Could be useful when working with elements that are on the screen at the first render, and we don't want to wait for InersectionObserver initialization to make some actions.|
 
 ## License
 

--- a/lib/useOnScreen.tsx
+++ b/lib/useOnScreen.tsx
@@ -28,6 +28,11 @@ export type UseOnScreenSettings<T extends HTMLElement = HTMLElement> = {
    * @example ```50px 0 0 | 50px | 2rem 3rem```
    */
   margin?: string;
+  /**
+   * Initial isOnScreen value.
+   * @default false
+   */
+  initialVisibility?: boolean;
 };
 
 /**
@@ -46,8 +51,9 @@ export const useOnScreen = <T extends HTMLElement>({
   threshold = 0,
   once = false,
   margin,
+  initialVisibility = false,
 }: UseOnScreenSettings<T>) => {
-  const [isIntersecting, setIntersecting] = useState(false);
+  const [isIntersecting, setIntersecting] = useState(initialVisibility);
   const [intersectionRatio, setIntersectionRatio] = useState<number>();
 
   useEffect(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukorvl/react-on-screen",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukorvl/react-on-screen",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "hoist-non-react-statics": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukorvl/react-on-screen",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Lightweight typescript library to detect React elements visibility",
   "license": "MIT",
   "author": "ukorvl",


### PR DESCRIPTION
Add ```initialVisibility``` prop to useOnScreen hook. This could be useful when user wants to initialize react component with that value and don't want to wait for rendering HTML node and Intersection Observer action.
This could be used as a kind of optimization, e. g. to prevent unnecessary calculations on initial render.

```tsx
<OnScreen initialVisibility={true}>{...}</OnScreen>
```