### PR TITLE
Renamed UseOnScreenSettings to UseOnScreenParameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ export const ListWithOnScreen = WithOnScreen(List, {threshold: 0.5, margin: '4re
 |threshold       |0                |Could be a single number from 0 to 1, or array of numbers. If you only want to detect when visibility passes the 50% mark, you can use a value of 0.5. Set 1 to consider visibility only if all element is on the screen.If array of thresholds is provided, visibility detection will be triggered every time visibility passes one of provided thresholds.|
 |margin          |undefined        |Could be any valid css margin value. This value serves to grow or shrink each side of the target element's bounding box before computing is it visible or not.|
 |once            |false            |Triggers visibility detection only once. Once target element becomes visible, visibility detection will be disabled.|
-|initialVisibility |false          |Initial isOnScreen value. Could be useful when working with elements that are on the screen at the first render, and we don't want to wait for InersectionObserver initialization to make some actions.|
+|initialVisibility |false          |Initial isOnScreen value. Could be useful when working with elements that are on the screen at the first render, and we don't want to wait for InersectionObserver initialization to do some actions.|
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ export const ListWithOnScreen = WithOnScreen(List, {threshold: 0.5, margin: '4re
 ```
 
 ### API
-**useOnScreen** hook settings. **OnScreen** and **WithOnScreen** components have the same api, except ref. **useOnScreen** consumes target element ref as a setting, but components deal with target element in a different way.
+**useOnScreen** hook parameters. **OnScreen** and **WithOnScreen** components have the same api, except ref. **useOnScreen** consumes target element ref as a parameter, but components deal with target element in a different way.
 
 |Name            |Default         |Description        |
 |----------------|----------------|-------------------|
-|threshold       |0                |Could be a single number from 0 to 1, or array of numbers. If you only want to detect when visibility passes the 50% mark, you can use a value of 0.5. Set 1 to consider visibility only if all element is on the screen.If array of thresholds is provided, visibility detection will be triggered every time visibility passes one of provided thresholds.|
+|threshold       |0                |Could be a single number from 0 to 1, or array of numbers. If you only want to detect when visibility passes the 50% mark, you can use a value of 0.5. Set 1 to consider visibility only if all element is on the screen. If array of thresholds is provided, visibility detection will be triggered every time visibility passes one of provided thresholds.|
 |margin          |undefined        |Could be any valid css margin value. This value serves to grow or shrink each side of the target element's bounding box before computing is it visible or not.|
 |once            |false            |Triggers visibility detection only once. Once target element becomes visible, visibility detection will be disabled.|
 |initialVisibility |false          |Initial isOnScreen value. Could be useful when working with elements that are on the screen at the first render, and we don't want to wait for InersectionObserver initialization to do some actions.|

--- a/lib/OnScreen.tsx
+++ b/lib/OnScreen.tsx
@@ -7,7 +7,7 @@ import React, {
   ElementType,
   ComponentProps,
 } from 'react';
-import { UseOnScreenSettings, useOnScreen } from './useOnScreen';
+import { UseOnScreenParameters, useOnScreen } from './useOnScreen';
 
 /**
  * OnScreen component own props.
@@ -26,7 +26,7 @@ type OnScreenOwnProps<
    * Element to render.
    */
   as?: AS;
-} & Omit<UseOnScreenSettings<T>, 'ref'>;
+} & Omit<UseOnScreenParameters<T>, 'ref'>;
 
 /**
  * OnScreen component props with generic element props.

--- a/lib/__tests__/testUtils.ts
+++ b/lib/__tests__/testUtils.ts
@@ -2,13 +2,13 @@
 import { act, render } from '@testing-library/react';
 import { mockIntersectionObserver } from 'jsdom-testing-mocks';
 import { ReactElement } from 'react';
-import { UseOnScreenSettings } from '../useOnScreen';
+import { UseOnScreenParameters } from '../useOnScreen';
 
 /**
  * Renders component.
  */
 export type ComponentRenderer = (
-  settings?: Pick<UseOnScreenSettings, 'once'>,
+  settings?: Pick<UseOnScreenParameters, 'once'>,
 ) => ReactElement;
 
 const targetTestId = 'target';

--- a/lib/__tests__/useOnScreen.test.tsx
+++ b/lib/__tests__/useOnScreen.test.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { useOnScreen, UseOnScreenSettings } from '../useOnScreen';
+import { useOnScreen, UseOnScreenParameters } from '../useOnScreen';
 import {
   ComponentRenderer,
   createIsOnScreenValueTest,
@@ -7,7 +7,7 @@ import {
   createRenderTest,
 } from './testUtils';
 
-const ComponentTemplate = (props: Pick<UseOnScreenSettings, 'once'>) => {
+const ComponentTemplate = (props: Pick<UseOnScreenParameters, 'once'>) => {
   const ref = useRef(null);
   const { isOnScreen } = useOnScreen({ ref, ...props });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 export { useOnScreen } from './useOnScreen';
-export type { UseOnScreenSettings } from './useOnScreen';
+export type { UseOnScreenParameters } from './useOnScreen';
 export { OnScreen } from './OnScreen';
 export type { OnScreenProps } from './OnScreen';
 export { withOnScreen } from './withOnScreen';
+export type { WithOnScreenWrappedComponent } from './withOnScreen';

--- a/lib/useOnScreen.tsx
+++ b/lib/useOnScreen.tsx
@@ -3,7 +3,7 @@ import { RefObject, useEffect, useState } from 'react';
 /**
  * UseOnScreen hook settings.
  */
-export type UseOnScreenSettings<T extends HTMLElement = HTMLElement> = {
+export type UseOnScreenParameters<T extends HTMLElement = HTMLElement> = {
   /**
    * Target React element ref.
    */
@@ -43,7 +43,7 @@ export type UseOnScreenSettings<T extends HTMLElement = HTMLElement> = {
  *
  * return (<div ref={ref}>{isOnScreen ? 'On screen!' : 'Not on screen'}</div>);
  * ```
- * @param {UseOnScreenSettings} useOnScreenProps - Props.
+ * @param {UseOnScreenParameters} useOnScreenParameters - Parameters.
  * @returns .
  */
 export const useOnScreen = <T extends HTMLElement>({
@@ -52,7 +52,7 @@ export const useOnScreen = <T extends HTMLElement>({
   once = false,
   margin,
   initialVisibility = false,
-}: UseOnScreenSettings<T>) => {
+}: UseOnScreenParameters<T>) => {
   const [isIntersecting, setIntersecting] = useState(initialVisibility);
   const [intersectionRatio, setIntersectionRatio] = useState<number>();
 

--- a/lib/withOnScreen.tsx
+++ b/lib/withOnScreen.tsx
@@ -1,7 +1,14 @@
 import React, { useRef, ComponentType, forwardRef, ForwardedRef } from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { UseOnScreenSettings, useOnScreen } from './useOnScreen';
+import { UseOnScreenParameters, useOnScreen } from './useOnScreen';
 import { assignRefs } from './internal';
+
+/**
+ * WithOnScreen wrapped component with injected props.
+ */
+export type WithOnScreenWrappedComponent<
+  Props extends Record<string, unknown>,
+> = ComponentType<Props & ReturnType<typeof useOnScreen>>;
 
 /**
  * High order component that takes a component and injects onScreen props into it.
@@ -25,8 +32,8 @@ export const withOnScreen = <
   P extends Record<string, unknown>,
   T extends HTMLElement,
 >(
-  WrappedComponent: ComponentType<P & ReturnType<typeof useOnScreen>>,
-  settings?: Omit<UseOnScreenSettings<T>, 'ref'>,
+  WrappedComponent: WithOnScreenWrappedComponent<P>,
+  settings?: Omit<UseOnScreenParameters<T>, 'ref'>,
 ) => {
   const WithOnScreen = (props: P, forwardedRef: ForwardedRef<T>) => {
     const ref = useRef<T>(null);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukorvl/react-on-screen",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukorvl/react-on-screen",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "hoist-non-react-statics": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukorvl/react-on-screen",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Lightweight typescript library to detect React elements visibility",
   "license": "MIT",
   "author": "ukorvl",


### PR DESCRIPTION
Rename ```UseOnScreenSettings``` to ```UseOnScreenParameters``` which is more precise name. Also export ```WithOnScreenWrappedComponent``` type for usage in typescript projects.