### PR TITLE
Allow to use OnScreen without specifying html element type

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,6 +8,9 @@
       "recommended": true,
       "correctness": {
         "noUnusedVariables": "warn"
+      },
+      "suspicious": {
+        "noExplicitAny": "off"
       }
     }
   },

--- a/lib/OnScreen.tsx
+++ b/lib/OnScreen.tsx
@@ -12,7 +12,7 @@ import { UseOnScreenParameters, useOnScreen } from "./useOnScreen";
 /**
  * OnScreen component own props.
  */
-type OnScreenOwnProps<T extends HTMLElement, AS extends ElementType = ElementType> = {
+type OnScreenOwnProps<T extends HTMLElement = any, AS extends ElementType = ElementType> = {
   /**
    * Render function.
    */
@@ -27,7 +27,7 @@ type OnScreenOwnProps<T extends HTMLElement, AS extends ElementType = ElementTyp
  * OnScreen component props with generic element props.
  */
 export type OnScreenProps<
-  T extends HTMLElement,
+  T extends HTMLElement = any,
   AS extends ElementType = ElementType,
 > = OnScreenOwnProps<T, AS> & Omit<ComponentProps<AS>, keyof OnScreenOwnProps<T, AS>>;
 
@@ -46,7 +46,7 @@ export type OnScreenProps<
  * @param {OnScreenProps} onScreenComponentProps Props.
  * @returns Children elements with on-screen wrapper.
  */
-export const OnScreen = <T extends HTMLElement, AS extends ElementType = ElementType>({
+export const OnScreen = <T extends HTMLElement = any, AS extends ElementType = ElementType>({
   children,
   margin,
   threshold,

--- a/lib/useOnScreen.tsx
+++ b/lib/useOnScreen.tsx
@@ -3,7 +3,7 @@ import { RefObject, useEffect, useState } from "react";
 /**
  * UseOnScreen hook settings.
  */
-export type UseOnScreenParameters<T extends HTMLElement = HTMLElement> = {
+export type UseOnScreenParameters<T extends HTMLElement> = {
   /**
    * Target React element ref.
    */

--- a/lib/useOnScreen.tsx
+++ b/lib/useOnScreen.tsx
@@ -3,7 +3,7 @@ import { RefObject, useEffect, useState } from "react";
 /**
  * UseOnScreen hook settings.
  */
-export type UseOnScreenParameters<T extends HTMLElement> = {
+export type UseOnScreenParameters<T extends HTMLElement = any> = {
   /**
    * Target React element ref.
    */
@@ -46,7 +46,7 @@ export type UseOnScreenParameters<T extends HTMLElement> = {
  * @param {UseOnScreenParameters} useOnScreenParameters - Parameters.
  * @returns .
  */
-export const useOnScreen = <T extends HTMLElement>({
+export const useOnScreen = <T extends HTMLElement = any>({
   ref,
   threshold = 0,
   once = false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukorvl/react-on-screen",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukorvl/react-on-screen",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "hoist-non-react-statics": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukorvl/react-on-screen",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Lightweight typescript library to detect React elements visibility",
   "license": "MIT",
   "author": "ukorvl",


### PR DESCRIPTION
closes #12 

This diff adds default `any` value for a generic type parameter of OnScreen element. It will be much more convenient to use component without always specifying generic like `<OnScreen<HTMLUlListElement>> ...`