### PR TITLE
Minor workflow fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ inputs.should_pack == true }}
         run: |
           VERSION=$(node -pe 'require("./package.json").version')
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Upload build result
         if: ${{ inputs.should_pack == true }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,8 +48,6 @@ jobs:
     if: ${{ needs.ensure_version_changed.outputs.version }}
     name: Publish to npm
     steps:
-    - name: echo
-      run: echo ${{ needs.ensure_version_changed.outputs.version }}
     - name: Download artifact
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,8 @@ jobs:
     if: ${{ needs.ensure_version_changed.outputs.version }}
     name: Publish to npm
     steps:
+    - name: echo
+      run: echo ${{ needs.ensure_version_changed.outputs.version }}
     - name: Download artifact
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Ensure that version was changed
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.check_version.outputs.version }}
+      version: xxx
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -18,7 +18,6 @@ jobs:
 
       - name: Check if version was changed
         id: check_version
-        shell: bash
         run: |
           NEW_PACKAGE_VERSION=$(node -pe 'require("./package.json").version')
           echo "$NEW_PACKAGE_VERSION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
 
           if [ $NEW_PACKAGE_VERSION != $OLD_PACKAGE_VERSION ]; then
             echo "Version was changed"
-            echo "version=$NEW_PACKAGE_VERSION" >> $GITHUB_OUTPUT
+            echo "version=xxxx" >> $GITHUB_OUTPUT
           fi
 
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,8 @@ jobs:
           echo "$OLD_PACKAGE_VERSION"
 
           if [ $NEW_PACKAGE_VERSION != $OLD_PACKAGE_VERSION ]; then
-            echo "{version}={$NEW_PACKAGE_VERSION}" >> $GITHUB_OUTPUT
+            echo "Version was changed"
+            echo "version=$NEW_PACKAGE_VERSION" >> $GITHUB_OUTPUT
           fi
 
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Ensure that version was changed
     runs-on: ubuntu-latest
     outputs:
-      version: xxx
+      version: ${{ steps.check_version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build, ensure_version_changed]
     if: ${{ needs.ensure_version_changed.outputs.version }}
     name: Publish to npm
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Check if version was changed
         id: check_version
+        shell: bash
         run: |
           NEW_PACKAGE_VERSION=$(node -pe 'require("./package.json").version')
           echo "$NEW_PACKAGE_VERSION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,12 +20,14 @@ jobs:
         id: check_version
         run: |
           NEW_PACKAGE_VERSION=$(node -pe 'require("./package.json").version')
+          echo "$NEW_PACKAGE_VERSION"
 
           latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
 
           git checkout $latestTag
 
           OLD_PACKAGE_VERSION=$(node -pe 'require("./package.json").version')
+          echo "$OLD_PACKAGE_VERSION"
 
           if [ $NEW_PACKAGE_VERSION != $OLD_PACKAGE_VERSION ]; then
             echo "{version}={$NEW_PACKAGE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
           OLD_PACKAGE_VERSION=$(node -pe 'require("./package.json").version')
 
           if [ $NEW_PACKAGE_VERSION != $OLD_PACKAGE_VERSION ]; then
-            echo "::set-output name=version::$NEW_PACKAGE_VERSION"
+            echo "{version}={$NEW_PACKAGE_VERSION}" >> $GITHUB_OUTPUT
           fi
 
   build:


### PR DESCRIPTION
This diff removes deprecated `set-output` actions api and fixes error with incomplete `needs` list.