### PR TITLE
Switch to actions/upload-artifact v4 since v3 is deprecated

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload build result
         if: ${{ inputs.should_pack == true }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ukorvl-react-on-screen-${{ steps.get_version.outputs.version }}
           path: ukorvl-react-on-screen-${{ steps.get_version.outputs.version }}.tgz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
     name: Publish to npm
     steps:
     - name: Download artifact
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: ukorvl-react-on-screen-${{ needs.ensure_version_changed.outputs.version }}
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,6 @@
   "editor.formatOnPaste": true,
   "editor.formatOnType": true,
   "editor.codeActionsOnSave": {
-    "quickfix.biome": true
+    "quickfix.biome": "explicit"
   }
 }


### PR DESCRIPTION
This patch changes version of actions/upload-artifact action in CI from 3 to 4, since v3 is deprecated and usage of it results in a broken workflow.